### PR TITLE
Restricted In/Banned In filter, Access all cards of a Cycle/Pack via url param

### DIFF
--- a/client/src/components/CardFilter.tsx
+++ b/client/src/components/CardFilter.tsx
@@ -171,13 +171,14 @@ function filterReducer(state: FilterState, action: FilterAction): FilterState {
 }
 
 export function CardFilter(props: {
+  initialFilterState?: FilterState | undefined,
   onFilterChanged: (filter: FilterState) => void
   fullWidth?: boolean
   deckbuilder?: boolean
 }): JSX.Element {
   const classes = useStyles()
   const { traits } = useUiStore()
-  const [ filterState, dispatchFilter ] = useReducer(filterReducer, initialState);
+  const [ filterState, dispatchFilter ] = useReducer(filterReducer, props.initialFilterState || initialState);
   useEffect(() => props.onFilterChanged(filterState), [filterState]);
 
   const [ searchTerm, setSearchTerm ] = useState('');

--- a/client/src/providers/UiStoreProvider.tsx
+++ b/client/src/providers/UiStoreProvider.tsx
@@ -23,8 +23,8 @@ export function UiStoreProvider(props: { children: ReactNode }): JSX.Element {
   const [traits, setTraits] = useState<Trait[]>([])
 
   useEffect(() => {
-    publicApi.Card.findAll().then((cards) => setCards(cards.data()))
     publicApi.Pack.findAll().then((packs) => setPacks(packs.data()))
+    publicApi.Card.findAll().then((cards) => setCards(cards.data()))
     publicApi.Cycle.findAll().then((cycles) => setCycles(cycles.data()))
     publicApi.Trait.findAll().then((traits) => setTraits(traits.data()))
   }, [])


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8974341/120930313-077b4500-c6ed-11eb-9e25-3fb42144e144.png)

Also adds support for initially setting a filter via url query param (eg. /cards?cycle=dominion will preset the pack filter to include all 6 Dominion Cycle packs)