### PR TITLE
Rulings bot

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,13 +1,16 @@
 import bodyParser from 'body-parser'
 import cors from 'cors'
-import express, { Express, Request, Response } from 'express'
+import express, { Request, Response } from 'express'
 import helmet from 'helmet'
+import { Server } from 'http'
 import path from 'path'
 
 import env from './env'
 import api from './api'
+import { Service } from './typings/Service'
 
-export default async (): Promise<{ app: Express; run: () => void }> => {
+export default async (): Promise<Service> => {
+  console.log('SERVER: initializing')
   const app = express()
 
   app.use(helmet({ contentSecurityPolicy: false }))
@@ -21,12 +24,30 @@ export default async (): Promise<{ app: Express; run: () => void }> => {
     res.sendFile(path.resolve(__dirname, 'public', 'index.html'))
   })
 
+  let server: Server | undefined
   return {
-    app,
-    run: (): void => {
-      app.listen(env.serverPort, () => {
-        console.log(`server started at http://localhost:${env.serverPort}`)
+    async run() {
+      server = app.listen(env.serverPort, () => {
+        console.log(`SERVER: ready. Listening at http://localhost:${env.serverPort}`)
       })
     },
+    async shutdown() {
+      console.log('SERVER: shutdown start')
+      if (server) {
+        await asyncCloseServer(server)
+        console.log('SERVER: shutdown done')
+      }
+    },
   }
+}
+
+async function asyncCloseServer(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) {
+        return reject(err)
+      }
+      resolve()
+    })
+  })
 }

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,1 +1,1 @@
-export { startBot } from './private/bot'
+export { createBot } from './private/bot'

--- a/src/bot/private/bot.ts
+++ b/src/bot/private/bot.ts
@@ -1,12 +1,12 @@
-import { Client, Intents } from 'discord.js'
-
-import { Config } from './types'
-import { command as cardCommand } from './commands/card'
-
 import { REST } from '@discordjs/rest'
+import { Client, Intents } from 'discord.js'
 import { Routes } from 'discord-api-types/v9'
 
-export async function startBot(config: Config): Promise<void> {
+import { Service } from '../../typings/Service'
+import { command as cardCommand } from './commands/card'
+import { Config } from './types'
+
+export async function createBot(config: Config): Promise<Service> {
   console.log('BOT: registering commands')
   await registerCommands(config)
 
@@ -22,8 +22,17 @@ export async function startBot(config: Config): Promise<void> {
     }
   })
 
+  return {
+    async run() {
   await client.login(config.botToken)
-  console.log('BOT: done')
+      console.log('BOT: running')
+    },
+    async shutdown() {
+      console.log('BOT: shutdown start')
+      client.destroy()
+      console.log('BOT: shutdown done')
+    },
+  }
 }
 
 async function registerCommands(config: Config): Promise<unknown> {

--- a/src/bot/private/bot.ts
+++ b/src/bot/private/bot.ts
@@ -4,6 +4,7 @@ import { Routes } from 'discord-api-types/v9'
 
 import { Service } from '../../typings/Service'
 import { command as cardCommand } from './commands/card'
+import { command as rulingsCommand } from './commands/rulings'
 import { Config } from './types'
 
 export async function createBot(config: Config): Promise<Service> {
@@ -19,12 +20,14 @@ export async function createBot(config: Config): Promise<Service> {
     switch (interaction.commandName) {
       case cardCommand.name:
         return cardCommand.handler(interaction)
+      case rulingsCommand.name:
+        return rulingsCommand.handler(interaction)
     }
   })
 
   return {
     async run() {
-  await client.login(config.botToken)
+      await client.login(config.botToken)
       console.log('BOT: running')
     },
     async shutdown() {
@@ -37,6 +40,6 @@ export async function createBot(config: Config): Promise<Service> {
 
 async function registerCommands(config: Config): Promise<unknown> {
   const rest = new REST({ version: '9' }).setToken(config.botToken)
-  const body = [cardCommand.command].map((command) => command.toJSON())
+  const body = [cardCommand.command, rulingsCommand.command].map((command) => command.toJSON())
   return rest.put(Routes.applicationCommands(config.clientId), { body })
 }

--- a/src/bot/private/cardCache.ts
+++ b/src/bot/private/cardCache.ts
@@ -1,0 +1,83 @@
+import Fuse from 'fuse.js'
+import { getAllCards, getAllCardsInPacks } from '../../gateways/storage'
+import { CardInput, CardPackInput } from './types'
+
+interface Card {
+  id: string
+  image: string
+  name: string
+}
+type Registry = Map<Card['name'], Card>
+
+type NameFuzzySearch = Fuse<Card['name']>
+
+interface Cache {
+  registry: Registry
+  fuzzy: NameFuzzySearch
+  expiresAt: number
+}
+
+const cache: Cache = {
+  registry: new Map(),
+  expiresAt: 0, // Initialize the cache as expired
+  fuzzy: new Fuse([], { isCaseSensitive: false, includeScore: true, ignoreLocation: true }),
+}
+
+export async function fetchValidCache(): Promise<Cache> {
+  if (cache.expiresAt > Date.now()) {
+    return cache
+  }
+
+  cache.registry = await buildRegistry()
+  cache.expiresAt = fiveMinutesFromNow()
+  cache.fuzzy.setCollection(Array.from(cache.registry.keys()))
+
+  return cache
+}
+
+const fiveMinutesFromNow = () => Date.now() + 1000 * 60 * 5
+
+// ---------
+// REGISTRY
+// ---------
+async function buildRegistry(): Promise<Registry> {
+  const [cards, allCardsInPacks] = await Promise.all([getAllCards(), getAllCardsInPacks()])
+
+  // Pre-group by ID to keep this function as O(2n) instead of O(n2)
+  const images = new Map(allCardsInPacks.flatMap(idAndImageSkippingWhenImageIsMissing))
+
+  return new Map(cards.flatMap(nameAndImageSkippingWhenImageIsMissing(images)))
+}
+
+const idAndImageSkippingWhenImageIsMissing = (card: CardPackInput): [string, string][] => {
+  if (typeof card.image_url !== 'string') {
+    return []
+  }
+  return [[card.card_id, card.image_url]]
+}
+
+const nameAndImageSkippingWhenImageIsMissing =
+  (images: Map<string, string>) =>
+  (card: CardInput): [string, Card][] => {
+    const image = images.get(card.id)
+    if (typeof image !== 'string') {
+      return []
+    }
+
+    return [[extendedName(card), { image, id: card.id, name: card.name }]]
+  }
+
+const versionNumberRegex = /\((\d+)\)/ // Matches `(2)`, `(42)`, etc
+const extendedName = (card: CardInput) => {
+  if (!card.name_extra) {
+    return card.name
+  }
+
+  const match = versionNumberRegex.exec(card.name_extra)
+  if (match === null) {
+    return `${card.name} - ${card.name_extra}`
+  }
+
+  const [, versionNumber] = match
+  return `${card.name} ${versionNumber}`
+}

--- a/src/bot/private/cardsFuzzySearch.ts
+++ b/src/bot/private/cardsFuzzySearch.ts
@@ -1,9 +1,8 @@
-import Fuse from 'fuse.js'
-import { Card, CardInPack } from '@5rdb/api'
-import { getAllCards, getAllCardsInPacks } from '../../gateways/storage'
+import { fetchValidCache } from './cardCache'
+import { CachedCard } from './types'
 
 type NoMatch = { __tag: 'noMatch' }
-type SingleMatch = { __tag: 'singleMatch'; image: string }
+type SingleMatch = { __tag: 'singleMatch'; card: CachedCard }
 type MultiMatch = { __tag: 'multiMatch'; names: string[] }
 
 export async function search(query: string): Promise<NoMatch | SingleMatch | MultiMatch> {
@@ -14,92 +13,14 @@ export async function search(query: string): Promise<NoMatch | SingleMatch | Mul
     return { __tag: 'noMatch' }
   }
 
-  if (!second) {
-    // Matched a single item
-    const image = validCache.registry.get(first.item)
-    return !image ? { __tag: 'noMatch' } : { __tag: 'singleMatch', image }
-  }
-
-  if ((first.score ?? 0) * 1.5 <= (second.score ?? 0)) {
-    // First match is more than 50% better match than the second
-    const image = validCache.registry.get(first.item)
-    return !image ? { __tag: 'noMatch' } : { __tag: 'singleMatch', image }
+  const matchedSingleItem = !second
+  const firstMatch50pctBetterThanSecond = (first.score ?? 0) * 1.5 <= (second.score ?? 0)
+  if (matchedSingleItem || firstMatch50pctBetterThanSecond) {
+    const card = validCache.registry.get(first.item)
+    return !card ? { __tag: 'noMatch' } : { __tag: 'singleMatch', card }
   }
 
   // Multiple options
   const possibleMatches = results.map((res) => res.item)
   return { __tag: 'multiMatch', names: possibleMatches }
-}
-
-// ---------
-// IN-MEMORY CACHE
-// ---------
-interface Cache {
-  registry: Map<string, string>
-  fuzzy: Fuse<string>
-  expiresAt: number
-}
-const cache: Cache = {
-  registry: new Map(),
-  expiresAt: 0, // Initialize the cache as expired
-  fuzzy: new Fuse<string>([], { isCaseSensitive: false, includeScore: true, ignoreLocation: true }),
-}
-
-async function fetchValidCache(): Promise<Cache> {
-  if (cache.expiresAt > Date.now()) {
-    return cache
-  }
-
-  cache.registry = await buildRegistry()
-  cache.expiresAt = fiveMinutesFromNow()
-  cache.fuzzy.setCollection(Array.from(cache.registry.keys()))
-
-  return cache
-}
-
-const fiveMinutesFromNow = () => Date.now() + 1000 * 60 * 5
-
-// ---------
-// REGISTRY
-// ---------
-async function buildRegistry(): Promise<Map<string, string>> {
-  const [cards, allCardsInPacks] = await Promise.all([getAllCards(), getAllCardsInPacks()])
-
-  // Pre-group by ID to keep this function as O(2n) instead of O(n2)
-  const images = new Map(allCardsInPacks.flatMap(idAndImageSkippingWhenImageIsMissing))
-
-  return new Map(cards.flatMap(nameAndImageSkippingWhenImageIsMissing(images)))
-}
-
-const idAndImageSkippingWhenImageIsMissing = (card: CardInPack): [string, string][] => {
-  if (typeof card.image_url !== 'string') {
-    return []
-  }
-  return [[card.card_id, card.image_url]]
-}
-
-const nameAndImageSkippingWhenImageIsMissing =
-  (images: Map<string, string>) =>
-  (card: Card): [string, string][] => {
-    const image = images.get(card.id)
-    if (typeof image !== 'string') {
-      return []
-    }
-
-    return [[extendedName(card), image]]
-  }
-
-const versionNumberRegex = /\((\d+)\)/ // Matches `(2)`, `(42)`, etc
-const extendedName = (card: Card) => {
-  if (!card.name_extra) {
-    return card.name
-  }
-
-  const match = versionNumberRegex.exec(card.name_extra)
-  if (match === null) {
-    return `${card.name} - ${card.name_extra} `
-  }
-
-  const [, versionNumber] = match
-  return `${card.name} ${versionNumber}`
 }

--- a/src/bot/private/commands/card.ts
+++ b/src/bot/private/commands/card.ts
@@ -2,8 +2,7 @@ import { DiscordAPIError } from 'discord.js'
 import { SlashCommandBuilder } from '@discordjs/builders'
 import { search } from '../cardsFuzzySearch'
 import { Command } from '../types'
-
-const list = new Intl.ListFormat('en', { style: 'long', type: 'disjunction' })
+import { listAlternatives } from '../format'
 
 const name = 'card'
 
@@ -32,12 +31,13 @@ export const command: Command = {
         })
       }
       if (result.__tag === 'singleMatch') {
-        return interaction.reply(result.image)
+        return interaction.reply(result.card.image)
       }
+
       const candidates = result.names.map((name) => `\`${name}\``)
       return interaction.reply({
         ephemeral: true,
-        content: `I'm not sure I follow you. Maybe you're looking for ${list.format(candidates)}?`,
+        content: `I'm not sure I follow you. Are you looking for ${listAlternatives(candidates)}?`,
       })
     } catch (e) {
       if (e instanceof DiscordAPIError) {

--- a/src/bot/private/commands/rulings.ts
+++ b/src/bot/private/commands/rulings.ts
@@ -1,0 +1,109 @@
+import { DiscordAPIError, MessageEmbedOptions, ColorResolvable } from 'discord.js'
+import { SlashCommandBuilder } from '@discordjs/builders'
+import { getAllRulingsForCard } from '../../../gateways/storage'
+import { search } from '../cardsFuzzySearch'
+import { CachedCard, Command, RulingInput } from '../types'
+import { listAlternatives } from '../format'
+
+const name = 'rulings'
+
+export const command: Command = {
+  name,
+  command: new SlashCommandBuilder()
+    .setName(name)
+    .setDescription("Replies with rulings for the card you're looking for")
+    .addStringOption((option) =>
+      option
+        .setName('name')
+        .setDescription('The name of the card or a part of its name')
+        .setRequired(true)
+    ),
+
+  async handler(interaction) {
+    const query = interaction.options.getString('name')
+    if (!query) return
+
+    const result = await search(query)
+    try {
+      if (result.__tag === 'noMatch') {
+        return interaction.reply({
+          ephemeral: true,
+          content: `I am sorry, but I have no idea what you are looking for`,
+        })
+      }
+      if (result.__tag === 'multiMatch') {
+        const candidates = result.names.map((name) => `\`${name}\``)
+        return interaction.reply({
+          ephemeral: true,
+          content: `I'm not sure I follow you. Are you looking for ${listAlternatives(
+            candidates
+          )}?`,
+        })
+      }
+
+      const rulings = await getAllRulingsForCard(result.card.id)
+      /**
+       * We're sending each ruling as a separate reply using embeds.
+       *
+       * The embeds look nice and keep the replies clean, but each embed has a
+       * char count limit, and a reply with multiple embed have yet another char
+       * limit for the combioned embeds. That's why we put one embed per reply.
+       *
+       * Each interaction can get only one reply, but infinite `followUps`
+       */
+      const [firstEmbed, ...followUpEmbeds] = rulings.map(toEmbed(result.card))
+      await interaction.reply({ embeds: [firstEmbed] })
+      await Promise.all(followUpEmbeds.map((embed) => interaction.followUp({ embeds: [embed] })))
+    } catch (e) {
+      if (e instanceof DiscordAPIError) {
+        return
+      }
+      throw e
+    }
+  },
+}
+
+/**
+ *
+ * @see https://discordjs.guide/popular-topics/embeds.html#embed-limits
+ */
+const toEmbed =
+  (card: CachedCard) =>
+  (ruling: RulingInput): MessageEmbedOptions => ({
+    color: color(ruling),
+    author: {
+      name: truncate(256, card.name),
+      url: `https://www.emeralddb.org/card/${card.id}`,
+    },
+    title: truncate(256, `Rulling #${ruling.id}`),
+    url: ruling.link,
+    thumbnail: {
+      url: card.image,
+    },
+    description: truncate(4096, formatRulingText(ruling.text)),
+    footer: {
+      text: truncate(2048, ruling.source),
+    },
+  })
+
+function color(ruling: RulingInput): ColorResolvable {
+  switch (ruling.source) {
+    case 'Developer ruling':
+      return 'BLUE'
+    default:
+      return 'GREEN'
+  }
+}
+
+const links = /\[([^\]]+)]\([^)]+\)/g // Matches `[some text](some link)` and captures `some text`
+function formatRulingText(rawText: string): string {
+  return rawText.replace(links, (_, text) => `\`${text}\``).trim()
+}
+
+function truncate(n: number, str: string): string {
+  if (str.length <= n) {
+    return str
+  }
+  const subString = str.substring(0, n - 1)
+  return subString.substring(0, subString.lastIndexOf(' ')) + '…'
+}

--- a/src/bot/private/format.ts
+++ b/src/bot/private/format.ts
@@ -1,0 +1,5 @@
+const list = new Intl.ListFormat('en', { style: 'long', type: 'disjunction' })
+
+export function listAlternatives(alternatives: string[]): string {
+  return list.format(alternatives)
+}

--- a/src/bot/private/types.ts
+++ b/src/bot/private/types.ts
@@ -23,6 +23,12 @@ export interface CardPackInput {
   image_url?: string
 }
 
+export interface RulingInput {
+  id: number
+  text: string
+  source: string
+  link: string
+}
 
 export interface CachedCard {
   image: string

--- a/src/bot/private/types.ts
+++ b/src/bot/private/types.ts
@@ -11,3 +11,21 @@ export interface Command {
   command: Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>
   handler(interaction: CommandInteraction): Promise<void>
 }
+
+export interface CardInput {
+  id: string
+  name: string
+  name_extra?: string
+}
+
+export interface CardPackInput {
+  card_id: string
+  image_url?: string
+}
+
+
+export interface CachedCard {
+  image: string
+  id: string
+  name: string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,32 @@
 import 'source-map-support/register'
 
 import createApp from './app'
-import { startBot } from './bot'
+import { createBot } from './bot'
 import env from './env'
+import { Service } from './typings/Service'
 
-createApp().then(({ run }) => {
-  if (env.discord.isBotEnabled) {
-    startBot(env.discord) // This is async, but we don't need to wait for it
+const noBot: Service = {
+  async run() {
+    console.log('BOT: skip')
+  },
+  async shutdown() {
+    console.log('BOT: skip shutdown')
+  },
+}
+
+Promise.all([createApp(), env.discord.isBotEnabled ? createBot(env.discord) : noBot]).then(
+  ([app, bot]) => {
+    app.run()
+    bot.run()
+
+    const shutdown = () => {
+      app.shutdown()
+      bot.shutdown()
+      process.exit(0)
+    }
+
+    process.on('SIGINT', shutdown)
+    process.on('SIGTERM', shutdown)
+    process.on('SIGQUIT', shutdown)
   }
-
-  run()
-})
+)

--- a/src/typings/Service.ts
+++ b/src/typings/Service.ts
@@ -1,0 +1,4 @@
+export interface Service {
+  run(): Promise<void>
+  shutdown(): Promise<void>
+}


### PR DESCRIPTION
We get some improvements to the server lifecycle with `shutdown` methods added to the Service interface. We call shutdown, before we shutdown (_uow!_). Currently that logs out the bot, which is not essential but it's more elegant than leaving it there to timeout. In the future it could be used to disconnect database connections etc.

Then the main function, of implementing the `/rulings some card name` command into the bot.

I suggest reviewing the code commit by commit.