### PR TITLE
Update link to emerald edict pdf

### DIFF
--- a/client/src/views/OpLists.tsx
+++ b/client/src/views/OpLists.tsx
@@ -13,7 +13,7 @@ const formats = [
   {
     id: 'emerald',
     name: 'Emerald Legacy - Emerald Edict',
-    link: 'https://emeraldlegacy.org/rules/',
+    link: 'https://emerald-legacy.github.io/rules-documents/Emerald%20Edict.pdf',
   },
   {
     id: 'standard',


### PR DESCRIPTION
Instead of linking to just emeraldlegacy.org/rules, we now link directly to the PDF version of the edict.