### PR TITLE
Hide rotated cards in deck builder

### DIFF
--- a/client/src/components/CardFilter.tsx
+++ b/client/src/components/CardFilter.tsx
@@ -322,7 +322,11 @@ export function applyFilters(cards: CardWithVersions[], formats: Format[], filte
       }
     } else {
       if (filter.illegal === 'false') {
-        filteredCards = filteredCards.filter((c) => c.versions.some((version) => legalPacksOfFormat.some(pack => version.pack_id === pack)))
+        filteredCards = filteredCards.filter((c) =>
+          c.versions.some((version) =>
+            legalPacksOfFormat.some((pack) => version.pack_id === pack) && !version.rotated
+          )
+        )
       }
       if (filter.restricted === 'false') {
         filteredCards = filteredCards.filter((c) => !c.restricted_in?.includes(filter.format))

--- a/client/src/components/builder/DeckEditor.tsx
+++ b/client/src/components/builder/DeckEditor.tsx
@@ -110,7 +110,9 @@ function prefilterCards(cards: CardWithVersions[], decklist: DecklistViewModel, 
     if (chosenFormat && chosenFormat.legal_packs) {
       const legalPacksOfFormat = chosenFormat.legal_packs
       filteredCards = filteredCards.filter((c) =>
-        c.versions.some((version) => legalPacksOfFormat.includes(version.pack_id))
+        c.versions.some((version) =>
+          legalPacksOfFormat.includes(version.pack_id) && !version.rotated
+        )
       )
     }
   }

--- a/client/src/views/EditPackView.tsx
+++ b/client/src/views/EditPackView.tsx
@@ -265,7 +265,7 @@ export function EditPackView(): JSX.Element {
               <FormControlLabel
                 control={
                   <Checkbox
-                    value={rotated}
+                    checked={rotated}
                     onChange={(value) => setRotated(value.target.checked)}
                   />
                 }

--- a/src/handlers/rotatePack.ts
+++ b/src/handlers/rotatePack.ts
@@ -1,7 +1,9 @@
 import {
   getAllCardsInPack,
+  getAllFormats,
   getPack,
   insertOrUpdateCardInPack,
+  insertOrUpdateFormat,
   insertOrUpdatePack,
 } from '../gateways/storage/index'
 import { Pack, Pack$rotate } from '@5rdb/api'
@@ -25,5 +27,14 @@ export async function handler(
   )
   const rotatedPack = { ...pack, rotated: true }
   await insertOrUpdatePack(rotatedPack)
+
+  // Remove the rotated pack from the Emerald Legacy format's legal_packs array
+  const formats = await getAllFormats()
+  const emeraldFormat = formats.find((format) => format.id === 'emerald')
+  if (emeraldFormat && emeraldFormat.legal_packs?.includes(pack.id)) {
+    const updatedLegalPacks = emeraldFormat.legal_packs.filter((packId) => packId !== pack.id)
+    await insertOrUpdateFormat({ ...emeraldFormat, legal_packs: updatedLegalPacks })
+  }
+
   return rotatedPack
 }


### PR DESCRIPTION
- Properly display rotation status in "Edit Card" dialog
- Remove pack from list of legal packs in Emerald Legacy on rotation
- Do not show rotated cards in deck builder

Close #79 