### PR TITLE
Admin: edit pack metadata + derive pack.size from cards_in_packs

### DIFF
--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -15,6 +15,7 @@ const DecksView = lazy(() => import('./views/DecksView').then(m => ({ default: m
 const EditCardView = lazy(() => import('./views/EditCardView').then(m => ({ default: m.EditCardView })))
 const EditDeckView = lazy(() => import('./views/EditDeckView').then(m => ({ default: m.EditDeckView })))
 const EditPackCardsView = lazy(() => import('./views/EditPackCardsView').then(m => ({ default: m.EditPackCardsView })))
+const EditPackView = lazy(() => import('./views/EditPackView').then(m => ({ default: m.EditPackView })))
 const ManageCyclesView = lazy(() => import('./views/ManageCyclesView').then(m => ({ default: m.ManageCyclesView })))
 const NotLoggedIn = lazy(() => import('./views/NotLoggedIn').then(m => ({ default: m.NotLoggedIn })))
 const NotPermitted = lazy(() => import('./views/NotPermitted').then(m => ({ default: m.NotPermitted })))
@@ -62,6 +63,7 @@ export function Routes(): JSX.Element {
         <Route path="/card/:id/edit" element={<DataAdminRoute><EditCardView /></DataAdminRoute>} />
         <Route path="/card/create/new" element={<DataAdminRoute><CreateCardView /></DataAdminRoute>} />
         <Route path="/admin/pack/:id/cards" element={<DataAdminRoute><EditPackCardsView /></DataAdminRoute>} />
+        <Route path="/admin/pack/:id/edit" element={<DataAdminRoute><EditPackView /></DataAdminRoute>} />
         <Route path="/admin/cycles" element={<DataAdminRoute><ManageCyclesView /></DataAdminRoute>} />
         <Route path="/admin/traits" element={<DataAdminRoute><EditTraitsView /></DataAdminRoute>} />
         <Route path="/admin/formats" element={<DataAdminRoute><EditFormatsView /></DataAdminRoute>} />

--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -14,7 +14,7 @@ const DeckDetailView = lazy(() => import('./views/DeckDetailView').then(m => ({ 
 const DecksView = lazy(() => import('./views/DecksView').then(m => ({ default: m.DecksView })))
 const EditCardView = lazy(() => import('./views/EditCardView').then(m => ({ default: m.EditCardView })))
 const EditDeckView = lazy(() => import('./views/EditDeckView').then(m => ({ default: m.EditDeckView })))
-const EditPackView = lazy(() => import('./views/EditPackView').then(m => ({ default: m.EditPackView })))
+const EditPackCardsView = lazy(() => import('./views/EditPackCardsView').then(m => ({ default: m.EditPackCardsView })))
 const ManageCyclesView = lazy(() => import('./views/ManageCyclesView').then(m => ({ default: m.ManageCyclesView })))
 const NotLoggedIn = lazy(() => import('./views/NotLoggedIn').then(m => ({ default: m.NotLoggedIn })))
 const NotPermitted = lazy(() => import('./views/NotPermitted').then(m => ({ default: m.NotPermitted })))
@@ -61,7 +61,7 @@ export function Routes(): JSX.Element {
         <Route path="/builder" element={<AuthenticatedRoute><BuilderView /></AuthenticatedRoute>} />
         <Route path="/card/:id/edit" element={<DataAdminRoute><EditCardView /></DataAdminRoute>} />
         <Route path="/card/create/new" element={<DataAdminRoute><CreateCardView /></DataAdminRoute>} />
-        <Route path="/admin/pack/:id" element={<DataAdminRoute><EditPackView /></DataAdminRoute>} />
+        <Route path="/admin/pack/:id/cards" element={<DataAdminRoute><EditPackCardsView /></DataAdminRoute>} />
         <Route path="/admin/cycles" element={<DataAdminRoute><ManageCyclesView /></DataAdminRoute>} />
         <Route path="/admin/traits" element={<DataAdminRoute><EditTraitsView /></DataAdminRoute>} />
         <Route path="/admin/formats" element={<DataAdminRoute><EditFormatsView /></DataAdminRoute>} />

--- a/client/src/views/EditPackCardsView.tsx
+++ b/client/src/views/EditPackCardsView.tsx
@@ -23,7 +23,7 @@ import { useSnackbar } from 'notistack'
 import { useConfirm } from "material-ui-confirm";
 import { getImageUrl } from '../utils/imageUrl'
 
-export function EditPackView(): JSX.Element {
+export function EditPackCardsView(): JSX.Element {
   const { cards, packs, invalidateData } = useUiStore()
   const params = useParams<{ id: string }>()
   const [cardId, setCardId] = useState('')

--- a/client/src/views/EditPackView.tsx
+++ b/client/src/views/EditPackView.tsx
@@ -1,0 +1,183 @@
+import {
+  Autocomplete,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Checkbox,
+  FormControlLabel,
+  TextField,
+  Typography,
+} from '@mui/material'
+import { useState, type JSX } from 'react'
+import { useNavigate, useParams } from 'react-router'
+import { useSnackbar } from 'notistack'
+import { Loading } from '../components/Loading'
+import { RequestError } from '../components/RequestError'
+import { useUiStore } from '../providers/UiStoreProvider'
+import { privateApi } from '../api'
+import type { Cycle, Pack } from '@5rdb/api'
+
+function toDateInputValue(released_at: unknown): string {
+  if (!released_at) return ''
+  // The Pack type says `Date | undefined`, but at runtime this is either an
+  // ISO-8601 string (from the JSON fetch) or a real Date (if something ever
+  // hands us one locally). Normalize both through Date so slice(0, 10)
+  // always yields the YYYY-MM-DD form an <input type="date"> expects.
+  try {
+    const iso = new Date(released_at as string | number | Date).toISOString()
+    return iso.slice(0, 10)
+  } catch {
+    return ''
+  }
+}
+
+export function EditPackView(): JSX.Element {
+  const { packs, cycles } = useUiStore()
+  const params = useParams<{ id: string }>()
+
+  if (!packs || !cycles) {
+    return <Loading />
+  }
+  const pack = packs.find((p) => p.id === params.id)
+  if (!pack) {
+    return <RequestError requestError="No pack for that ID!" />
+  }
+
+  return <EditPackForm pack={pack} cycles={cycles} />
+}
+
+function EditPackForm(props: { pack: Pack; cycles: Cycle[] }): JSX.Element {
+  const { pack, cycles } = props
+  const navigate = useNavigate()
+  const { enqueueSnackbar } = useSnackbar()
+  const { invalidateData } = useUiStore()
+
+  const [name, setName] = useState(pack.name)
+  const [position, setPosition] = useState(pack.position)
+  const [size, setSize] = useState(pack.size)
+  const [releasedAt, setReleasedAt] = useState(toDateInputValue(pack.released_at))
+  const [publisherId, setPublisherId] = useState(pack.publisher_id ?? '')
+  const [cycleId, setCycleId] = useState(pack.cycle_id)
+  const [rotated, setRotated] = useState(pack.rotated)
+  const [saving, setSaving] = useState(false)
+
+  const cycleValue = cycles.find((c) => c.id === cycleId) ?? null
+
+  async function save() {
+    setSaving(true)
+    try {
+      await privateApi.Pack.create({
+        body: {
+          id: pack.id,
+          name,
+          position,
+          size,
+          cycle_id: cycleId,
+          publisher_id: publisherId || undefined,
+          released_at: releasedAt || undefined,
+          rotated,
+        },
+      })
+      await invalidateData()
+      enqueueSnackbar('Pack updated', { variant: 'success' })
+      navigate('/admin/cycles')
+    } catch (error) {
+      console.log(error)
+      enqueueSnackbar("Couldn't update pack", { variant: 'error' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Box sx={{ maxWidth: 600, mx: 'auto', mt: 4, pb: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Edit Pack
+      </Typography>
+      <Card>
+        <CardContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              ID: {pack.id} (immutable)
+            </Typography>
+            <TextField
+              label="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              size="small"
+            />
+            <TextField
+              label="Position"
+              type="number"
+              value={position}
+              onChange={(e) => setPosition(Number.parseInt(e.target.value) || 0)}
+              required
+              size="small"
+            />
+            <TextField
+              label="Size"
+              type="number"
+              value={size}
+              onChange={(e) => setSize(Number.parseInt(e.target.value) || 0)}
+              required
+              size="small"
+            />
+            <TextField
+              label="Released at"
+              type="date"
+              value={releasedAt}
+              onChange={(e) => setReleasedAt(e.target.value)}
+              InputLabelProps={{ shrink: true }}
+              size="small"
+            />
+            <TextField
+              label="Publisher ID"
+              value={publisherId}
+              onChange={(e) => setPublisherId(e.target.value)}
+              placeholder="e.g. L5C01"
+              size="small"
+            />
+            <Autocomplete
+              options={[...cycles].sort((a, b) => a.name.localeCompare(b.name))}
+              getOptionLabel={(c) => c.name}
+              value={cycleValue}
+              onChange={(_event, value) => setCycleId(value?.id ?? '')}
+              isOptionEqualToValue={(a, b) => a.id === b.id}
+              renderInput={(params) => (
+                <TextField {...params} label="Cycle" required size="small" />
+              )}
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={rotated}
+                  onChange={(e) => setRotated(e.target.checked)}
+                />
+              }
+              label="Rotated out"
+            />
+          </Box>
+        </CardContent>
+      </Card>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2, mt: 2 }}>
+        <Button
+          variant="outlined"
+          onClick={() => navigate('/admin/cycles')}
+          disabled={saving}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={save}
+          disabled={saving || !name || !cycleId}
+        >
+          Save
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/client/src/views/EditPackView.tsx
+++ b/client/src/views/EditPackView.tsx
@@ -55,7 +55,6 @@ function EditPackForm(props: { pack: Pack; cycles: Cycle[] }): JSX.Element {
 
   const [name, setName] = useState(pack.name)
   const [position, setPosition] = useState(pack.position)
-  const [size, setSize] = useState(pack.size)
   const [releasedAt, setReleasedAt] = useState(toDateInputValue(pack.released_at))
   const [publisherId, setPublisherId] = useState(pack.publisher_id ?? '')
   const [cycleId, setCycleId] = useState(pack.cycle_id)
@@ -72,7 +71,6 @@ function EditPackForm(props: { pack: Pack; cycles: Cycle[] }): JSX.Element {
           id: pack.id,
           name,
           position,
-          size,
           cycle_id: cycleId,
           publisher_id: publisherId || undefined,
           released_at: releasedAt || undefined,
@@ -113,14 +111,6 @@ function EditPackForm(props: { pack: Pack; cycles: Cycle[] }): JSX.Element {
               type="number"
               value={position}
               onChange={(e) => setPosition(Number.parseInt(e.target.value) || 0)}
-              required
-              size="small"
-            />
-            <TextField
-              label="Size"
-              type="number"
-              value={size}
-              onChange={(e) => setSize(Number.parseInt(e.target.value) || 0)}
               required
               size="small"
             />

--- a/client/src/views/ManageCyclesView.tsx
+++ b/client/src/views/ManageCyclesView.tsx
@@ -259,6 +259,14 @@ export function ManageCyclesView(): JSX.Element {
                       variant="outlined"
                       color="secondary"
                       size="small"
+                      onClick={() => navigate(`/admin/pack/${pack.id}/edit`)}
+                    >
+                      Edit Pack
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      color="secondary"
+                      size="small"
                       onClick={() => navigate(`/admin/pack/${pack.id}/cards`)}
                     >
                       Edit Pack Cards

--- a/client/src/views/ManageCyclesView.tsx
+++ b/client/src/views/ManageCyclesView.tsx
@@ -259,7 +259,7 @@ export function ManageCyclesView(): JSX.Element {
                       variant="outlined"
                       color="secondary"
                       size="small"
-                      onClick={() => navigate(`/admin/pack/${pack.id}`)}
+                      onClick={() => navigate(`/admin/pack/${pack.id}/cards`)}
                     >
                       Edit Pack Cards
                     </Button>

--- a/client/src/views/ManageCyclesView.tsx
+++ b/client/src/views/ManageCyclesView.tsx
@@ -66,7 +66,6 @@ export function ManageCyclesView(): JSX.Element {
 
   const [packId, setPackId] = useState('')
   const [packName, setPackName] = useState('')
-  const [packSize, setPackSize] = useState(0)
   const [packPosition, setPackPosition] = useState(0)
   const [editedCycleId, setEditedCycleId] = useState('')
 
@@ -104,7 +103,6 @@ export function ManageCyclesView(): JSX.Element {
   function openPackModal(cycleId: string) {
     setPackId('')
     setPackName('')
-    setPackSize(0)
     setPackPosition(0)
     setEditedCycleId(cycleId)
     setPackModalOpen(true)
@@ -126,7 +124,6 @@ export function ManageCyclesView(): JSX.Element {
             cycle_id: editedCycleId,
             name: packName,
             id: packId,
-            size: packSize,
             position: packPosition,
           },
         })
@@ -306,14 +303,6 @@ export function ManageCyclesView(): JSX.Element {
             <Box padding={1.5} border="1px solid lightgray" borderRadius={1}>
               <Typography variant="body2">ID: {packId}</Typography>
             </Box>
-            <TextField
-              value={packSize}
-              variant="outlined"
-              onChange={(e) => setPackSize(Number.parseInt(e.target.value) || 0)}
-              type="number"
-              label="Pack Size"
-              size="small"
-            />
             <TextField
               value={packPosition}
               variant="outlined"

--- a/src/gateways/storage/private/pack.ts
+++ b/src/gateways/storage/private/pack.ts
@@ -3,17 +3,43 @@ import { Pack } from '@5rdb/api'
 
 export const TABLE = 'packs'
 
+// Columns on the `packs` table EXCEPT `size` — we compute that from
+// `cards_in_packs` rather than reading the stored value, which has drifted.
+const PACK_COLS = [
+  'packs.id',
+  'packs.name',
+  'packs.position',
+  'packs.released_at',
+  'packs.publisher_id',
+  'packs.cycle_id',
+  'packs.rotated',
+] as const
+
 export async function getAllPacks(): Promise<Pack[]> {
-  return pg(TABLE).select()
+  return pg(TABLE)
+    .select(...PACK_COLS)
+    .select(pg.raw('COUNT(DISTINCT cards_in_packs.card_id)::int AS size'))
+    .leftJoin('cards_in_packs', 'cards_in_packs.pack_id', 'packs.id')
+    .groupBy('packs.id')
 }
 
 export async function getPack(packId: string): Promise<Pack> {
-  return pg(TABLE).where('id', packId).first()
+  return pg(TABLE)
+    .select(...PACK_COLS)
+    .select(pg.raw('COUNT(DISTINCT cards_in_packs.card_id)::int AS size'))
+    .leftJoin('cards_in_packs', 'cards_in_packs.pack_id', 'packs.id')
+    .where('packs.id', packId)
+    .groupBy('packs.id')
+    .first()
 }
 
 export async function insertOrUpdatePack(pack: Pack): Promise<Pack> {
-  const insert = pg(TABLE).insert({ ...pack })
-  const update = pg.queryBuilder().update({ ...pack })
+  // `size` is derived on read; strip it from writes so the stored column
+  // stays whatever it was (dead storage) and we never drift further.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { size: _size, ...packWithoutSize } = pack
+  const insert = pg(TABLE).insert({ ...packWithoutSize })
+  const update = pg.queryBuilder().update({ ...packWithoutSize })
   const result = await pg.raw(`? ON CONFLICT ("id") DO ? returning *`, [insert, update])
   return result.rows[0]
 }

--- a/src/gateways/storage/private/pack.ts
+++ b/src/gateways/storage/private/pack.ts
@@ -18,7 +18,7 @@ const PACK_COLS = [
 export async function getAllPacks(): Promise<Pack[]> {
   return pg(TABLE)
     .select(...PACK_COLS)
-    .select(pg.raw('COUNT(DISTINCT cards_in_packs.card_id)::int AS size'))
+    .select(pg.raw('COALESCE(SUM(cards_in_packs.quantity), 0)::int AS size'))
     .leftJoin('cards_in_packs', 'cards_in_packs.pack_id', 'packs.id')
     .groupBy('packs.id')
 }
@@ -26,7 +26,7 @@ export async function getAllPacks(): Promise<Pack[]> {
 export async function getPack(packId: string): Promise<Pack> {
   return pg(TABLE)
     .select(...PACK_COLS)
-    .select(pg.raw('COUNT(DISTINCT cards_in_packs.card_id)::int AS size'))
+    .select(pg.raw('COALESCE(SUM(cards_in_packs.quantity), 0)::int AS size'))
     .leftJoin('cards_in_packs', 'cards_in_packs.pack_id', 'packs.id')
     .where('packs.id', packId)
     .groupBy('packs.id')

--- a/src/gateways/storage/private/pack.ts
+++ b/src/gateways/storage/private/pack.ts
@@ -3,8 +3,6 @@ import { Pack } from '@5rdb/api'
 
 export const TABLE = 'packs'
 
-// Columns on the `packs` table EXCEPT `size` — we compute that from
-// `cards_in_packs` rather than reading the stored value, which has drifted.
 const PACK_COLS = [
   'packs.id',
   'packs.name',
@@ -34,8 +32,6 @@ export async function getPack(packId: string): Promise<Pack> {
 }
 
 export async function insertOrUpdatePack(pack: Pack): Promise<Pack> {
-  // `size` is derived on read; strip it from writes so the stored column
-  // stays whatever it was (dead storage) and we never drift further.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { size: _size, ...packWithoutSize } = pack
   const insert = pg(TABLE).insert({ ...packWithoutSize })

--- a/src/handlers/createPack.ts
+++ b/src/handlers/createPack.ts
@@ -8,7 +8,6 @@ export const schema = {
     id: Joi.string().required(),
     name: Joi.string().required(),
     position: Joi.number().required(),
-    size: Joi.number().required(),
     cycle_id: Joi.string().required(),
     publisher_id: Joi.string(),
     released_at: Joi.date(),

--- a/src/handlers/createPack.ts
+++ b/src/handlers/createPack.ts
@@ -12,6 +12,7 @@ export const schema = {
     cycle_id: Joi.string().required(),
     publisher_id: Joi.string(),
     released_at: Joi.date(),
+    rotated: Joi.boolean(),
   }),
 }
 

--- a/src/handlers/createPack.ts
+++ b/src/handlers/createPack.ts
@@ -1,4 +1,4 @@
-import { insertOrUpdatePack } from '../gateways/storage/index'
+import { getPack, insertOrUpdatePack } from '../gateways/storage/index'
 import Joi from 'joi'
 import { ValidatedRequest } from '../middlewares/validator'
 import { Pack, Packs$create } from '@5rdb/api'
@@ -16,5 +16,6 @@ export const schema = {
 }
 
 export async function handler(req: ValidatedRequest<typeof schema>): Promise<Pack | undefined> {
-  return insertOrUpdatePack(req.body)
+  await insertOrUpdatePack(req.body)
+  return getPack(req.body.id)
 }


### PR DESCRIPTION
## Summary
- New admin page at `/admin/pack/:id/edit` for editing pack metadata (`name`, `position`, `released_at`, `publisher_id`, `cycle_id`, `rotated`). `id` remains immutable.
- Renamed the existing `/admin/pack/:id` (which actually edits the cards _inside_ a pack) to `/admin/pack/:id/cards`; component `EditPackView` → `EditPackCardsView`. This frees the `EditPackView` name for the new metadata editor.
- Backend: `PUT /packs` Joi schema now accepts `rotated` (was previously rejected with HTTP 400 despite being on the `Pack` type).
- `pack.size` is now **derived** from `SUM(cards_in_packs.quantity)` on every read rather than being an admin-maintained field. The stored column had drifted in several packs (e.g. `core` declared 350 but actual is 259). The DB column remains for now — no migration in this PR.

## Test plan
- [ ] `/admin/cycles` → click "Edit Pack" on any pack → form loads pre-populated → edit release date → Save → snackbar "Pack updated", redirect to `/admin/cycles`, DB reflects change.
- [ ] Move a pack between cycles via Edit Pack → appears under new cycle after save.
- [ ] Toggle rotated off on a rotated pack → red rotation icon disappears.
- [ ] `/admin/pack/:id/cards` (renamed cards editor) still works unchanged.
- [ ] "Add Pack" modal no longer has a Size field; new packs are created successfully.
- [ ] \`GET /api/packs\` returns each pack's \`size\` equal to the sum of card quantities.