### PR TITLE
Add GET /rulings endpoint returning all rulings

### DIFF
--- a/apiTypings/index.ts
+++ b/apiTypings/index.ts
@@ -53,6 +53,7 @@ export type {
   Decklists$publish,
   Decklists$unpublish,
   Decklists$validate,
+  Ruling$findAll,
   Ruling$create,
   Ruling$delete,
   Ruling$update,

--- a/apiTypings/private/apiEndpoints.ts
+++ b/apiTypings/private/apiEndpoints.ts
@@ -151,6 +151,10 @@ export interface Decklists$unpublish {
   request: { params: { decklistId: string } }
 }
 
+export interface Ruling$findAll {
+  response: Ruling[]
+}
+
 export interface Ruling$create {
   request: { body: Omit<Ruling, 'id'> }
   response: Ruling

--- a/src/api.ts
+++ b/src/api.ts
@@ -28,6 +28,7 @@ import * as updateCard from './handlers/updateCard'
 import * as renameCard from './handlers/renameCard'
 import * as deleteCard from './handlers/deleteCard'
 import * as createCard from './handlers/createCard'
+import * as getAllRulings from './handlers/getAllRulings'
 import * as updateRuling from './handlers/updateRuling'
 import * as createRuling from './handlers/createRuling'
 import * as deleteDeck from './handlers/deleteDeck'
@@ -86,6 +87,7 @@ export default (): Router => {
   api.post('/decklists/validate', w(validateDecklist.handler))
   api.delete('/decklists/:decklistId', authorizedOnly, w(deleteDecklist.handler))
   api.put('/decklists', authorizedOnly, w(createDecklist.handler))
+  api.get('/rulings', w(getAllRulings.handler))
   api.put('/rulings', authorizedOnly, w(rulesAdminOnly), w(createRuling.handler))
   api.post('/rulings/:rulingId', authorizedOnly, w(rulesAdminOnly), w(updateRuling.handler))
   api.delete('/rulings/:rulingId', authorizedOnly, w(rulesAdminOnly), w(deleteRuling.handler))

--- a/src/handlers/getAllRulings.ts
+++ b/src/handlers/getAllRulings.ts
@@ -1,0 +1,6 @@
+import { getAllRulings } from '../gateways/storage/index'
+import { Ruling } from '@5rdb/api'
+
+export async function handler(): Promise<Ruling[]> {
+  return getAllRulings()
+}


### PR DESCRIPTION
Exposes the existing getAllRulings storage function via a public read endpoint, mirroring the pattern of GET /cards and GET /packs. Useful for clients that want to load rulings up front rather than per-card.