### PR TITLE
Allow renaming with same name

### DIFF
--- a/client/src/views/CardDetailView.tsx
+++ b/client/src/views/CardDetailView.tsx
@@ -153,7 +153,13 @@ export function CardDetailView(): JSX.Element {
       })
       .catch((error) => {
         console.log(error)
-        enqueueSnackbar("The card couldn't be renamed!", { variant: 'error' })
+        const serverMessage = error?.data?.()
+        enqueueSnackbar(
+          serverMessage
+            ? `The card couldn't be renamed: ${serverMessage}`
+            : "The card couldn't be renamed!",
+          { variant: 'error' }
+        )
       })
   }
 

--- a/src/handlers/renameCard.ts
+++ b/src/handlers/renameCard.ts
@@ -64,6 +64,15 @@ export async function handler(
     res.status(400).send(`Card with id ${req.body.existingCardId} doesn't exist.`)
     return
   }
+
+  if (req.body.newCardId === req.body.existingCardId) {
+    return insertOrUpdateCard({
+      ...existingCard,
+      name: req.body.name,
+      name_extra: req.body.nameExtra,
+    })
+  }
+
   if (await getCard(req.body.newCardId)) {
     res.status(400).send(`Card with id ${req.body.newCardId} already exists.`)
     return


### PR DESCRIPTION
Sometimes, a card needs to be renamed because a word was misspelled (lower case / upper case). This requires the app to accept card renaming with the same ID.